### PR TITLE
Fixed download by/with manifest id

### DIFF
--- a/splash.go
+++ b/splash.go
@@ -109,7 +109,7 @@ func main() {
 		for _, id := range strings.Split(manifestID, ",") {
 			log.Printf("Fetching manifest %s...", id)
 
-			manifest, _, err := fetchManifest(fmt.Sprintf("https://download-dynamic.epicgames.com/Builds/Fortnite/CloudDir/%s.manifest", id))
+			manifest, _, err := fetchManifest(fmt.Sprintf("https://github.com/VastBlast/FortniteManifestArchive/raw/main/Fortnite/Windows/%s.manifest", id))
 			if err != nil {
 				log.Fatalf("Failed to fetch manifest: %v", err)
 			}


### PR DESCRIPTION
epic decided to delete the download-dynamic.epicgames.com server due to not needing a token downloading manifests which in turn could have been used to download basiclly any game without entitlement to a game.
so i changed this to use https://raw.githubusercontent.com/VastBlast/FortniteManifestArchive/main/Fortnite/Windows/%s.manifest instead.
same thing happened with https://api.nitestats.com/v1/epic/manifest?id= endpoint